### PR TITLE
Replace ‘Gender’ radio buttons in ‘Simple form example.’

### DIFF
--- a/doc/examples/simple.html
+++ b/doc/examples/simple.html
@@ -101,10 +101,10 @@ p.parsley-error {
   <label for="email">Email * :</label>
   <input type="email" class="form-control" name="email" data-parsley-trigger="change" required />
 
-  <label for="gender">Gender *:</label>
+  <label for="contactMethod">Preferred Contact Method *:</label>
   <p>
-    M: <input type="radio" name="gender" id="genderM" value="M" required />
-    F: <input type="radio" name="gender" id="genderF" value="F" />
+    Email: <input type="radio" name="contactMethod" id="contactMethodEmail" value="Email" required />
+    Phone: <input type="radio" name="contactMethod" id="contactMethodPhone" value="Phone" />
   </p>
 
   <label for="hobbies">Hobbies (Optional, but 2 minimum):</label>


### PR DESCRIPTION
This commit replaces the 'Gender' radio button field on the 'Simple form example' page. There are a few reasons for this:

- Gender is not binary, so offering only choices for 'male' and 'female' doesn’t reflect users’ experience and reality.
- [Asking for users' gender is problematic and unnecessary](https://uxdesign.cc/designing-forms-for-gender-diversity-and-inclusion-d8194cf1f51) in most cases, so let’s discourage its use as a common field.